### PR TITLE
Make "filter" argument nullable in ListDatabases

### DIFF
--- a/mongo/client.go
+++ b/mongo/client.go
@@ -450,7 +450,8 @@ func (c *Client) ListDatabases(ctx context.Context, filter interface{}, opts ...
 	}
 
 	filterDoc, err := transformBsoncoreDocument(c.registry, filter)
-	if err != nil {
+	// "filter" is optional in "listDatabases", ignore nil
+	if err != nil && err != ErrNilDocument {
 		return ListDatabasesResult{}, err
 	}
 


### PR DESCRIPTION
When using an Atlas M0 mongodb cluster, the `listDatabases` command normally works.

However, if the `filter` argument is included, the following error is returned:

> (AtlasError) Unallowed argument in listDatabases command: filter

This PR attempts to solve the issue by allowing users to omit the `filter` argument when calling `ListDatabases` and `ListDatabaseNames`.